### PR TITLE
fix: Claude Code GitHub Actions の権限設定を修正

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,15 +13,17 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor == 'kawaken' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## 概要
Claude Code GitHub Actions の権限設定を修正して、正常にファイルをコミット・PR作成できるようにします。

## 修正内容
### 1. 権限問題の解決
- `contents: write` - ファイルの書き込み権限を追加
- `pull-requests: write` - PRの作成権限を追加  
- `issues: write` - Issueへのコメント権限を追加

### 2. 実行権限の限定
- `github.actor == 'kawaken'` の条件を追加
- kawakenユーザーのみがClaude Codeを実行できるように制限

## 背景
Issue #2 での Claude Code 実行時に、ファイルの変更やPRの作成ができていなかった問題を解決します。

🤖 Generated with [Claude Code](https://claude.ai/code)