### PR TITLE
fix: Claude Code Actions に必要な MCP ツールの権限を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,7 +44,12 @@ jobs:
           
           # Allow Claude to run essential Git and Go commands
           allowed_tools: |
-            Bash(git add*),Bash(git commit*),Bash(git push*),Bash(git status),Bash(git diff*),Bash(go mod*),Bash(go test*),Bash(go build*),Bash(go run*),Bash(go get*)
+            Edit,MultiEdit,Glob,Grep,LS,Read,Write,
+            mcp__github_file_ops__commit_files,
+            mcp__github_file_ops__delete_files,
+            mcp__github_file_ops__update_claude_comment,
+            Bash(git add*),Bash(git commit*),Bash(git push*),Bash(git status),Bash(git diff*),
+            Bash(go mod*),Bash(go test*),Bash(go build*),Bash(go run*),Bash(go get*)
           
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"


### PR DESCRIPTION
Claude Code が GitHub 上でファイルをコミットできるよう、以下の MCP ツールを allowed_tools に追加:
- mcp__github_file_ops__commit_files: ファイルのコミット
- mcp__github_file_ops__delete_files: ファイルの削除
- mcp__github_file_ops__update_claude_comment: コメントの更新
- Edit,MultiEdit,Glob,Grep,LS,Read,Write: 基本的なファイル操作ツール

これにより Claude Code が正常にブランチへファイルをコミットし、PR を作成できるようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the range of permitted tools in the GitHub workflow, allowing broader file and GitHub operations during automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->