### PR TITLE
feat: PRマージ後のブランチ自動削除ワークフローを追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -7,8 +7,6 @@ on:
     types: [created]
   issues:
     types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   claude:
@@ -16,7 +14,6 @@ jobs:
       github.actor == 'kawaken' && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -1,0 +1,48 @@
+name: Delete Merged Branch
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-branch:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Delete merged branch
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const branchName = pr.head.ref;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            
+            // main ブランチは削除しない
+            if (branchName === 'main') {
+              console.log(`Skipping deletion of protected branch: ${branchName}`);
+              return;
+            }
+            
+            // フォークからの PR の場合はスキップ
+            if (pr.head.repo.full_name !== pr.base.repo.full_name) {
+              console.log('PR is from a fork, skipping branch deletion');
+              return;
+            }
+            
+            try {
+              await github.rest.git.deleteRef({
+                owner: owner,
+                repo: repo,
+                ref: `heads/${branchName}`
+              });
+              console.log(`Successfully deleted branch: ${branchName}`);
+            } catch (error) {
+              console.error(`Failed to delete branch ${branchName}:`, error.message);
+              // ブランチが既に削除されている場合はエラーを無視
+              if (error.status !== 422) {
+                throw error;
+              }
+            }

--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -19,10 +19,11 @@ jobs:
             const branchName = pr.head.ref;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const defaultBranch = context.payload.repository.default_branch;
             
-            // main ブランチは削除しない
-            if (branchName === 'main') {
-              console.log(`Skipping deletion of protected branch: ${branchName}`);
+            // デフォルトブランチは削除しない
+            if (branchName === defaultBranch) {
+              console.log(`Skipping deletion of default branch: ${branchName}`);
               return;
             }
             
@@ -30,6 +31,25 @@ jobs:
             if (pr.head.repo.full_name !== pr.base.repo.full_name) {
               console.log('PR is from a fork, skipping branch deletion');
               return;
+            }
+            
+            // 保護されたブランチかどうかをチェック
+            try {
+              const protection = await github.rest.repos.getBranchProtection({
+                owner: owner,
+                repo: repo,
+                branch: branchName
+              });
+              
+              if (protection.data) {
+                console.log(`Skipping deletion of protected branch: ${branchName}`);
+                return;
+              }
+            } catch (error) {
+              // 404エラーは保護されていないことを意味するので続行
+              if (error.status !== 404) {
+                console.log(`Warning: Could not check protection status for branch ${branchName}:`, error.message);
+              }
             }
             
             try {

--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -8,6 +8,8 @@ jobs:
   delete-branch:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
       - name: Delete merged branch


### PR DESCRIPTION
## Summary
- PRがマージされた後に自動的にブランチを削除するワークフローを追加
- デフォルトブランチと保護されたブランチは削除されない
- フォークからのPRは対象外（権限の問題を回避）
- PRレビューイベントでClaudeが動作しないように修正

## Changes
- feat: PRマージ後のブランチ自動削除ワークフローを追加
- improve: デフォルトブランチの動的取得と保護されたブランチのチェック機能を追加
- fix: ブランチ削除に必要な権限を追加
- fix: PRレビューイベントでClaudeが動作しないように修正

## Test plan
- [ ] このPRをマージしてワークフローが動作するか確認
- [ ] デフォルトブランチ（main）が保護されているか確認
- [ ] 保護されたブランチが削除されないか確認
- [ ] エラーハンドリングが適切に動作するか確認
- [ ] PRレビューでClaudeが起動しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced an automated workflow to delete branches after pull requests are merged, excluding protected and forked branches.
  * Simplified trigger conditions for an existing workflow by removing specific review event triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->