### PR TITLE
fix: check-go-version.yml のシンタックスエラーを修正

### DIFF
--- a/.github/workflows/check-go-version.yml
+++ b/.github/workflows/check-go-version.yml
@@ -42,7 +42,6 @@ jobs:
             echo "::error::GO_LATEST ($CURRENT_VERSION.x) is outdated! Latest stable Go version is $LATEST_MINOR.x"
             echo "Please update GO_LATEST in .github/workflows/ci.yml to $LATEST_MINOR.x"
             exit 1
-          fi
           else
             echo "✅ GO_LATEST is up to date ($CURRENT_VERSION.x)"
           fi


### PR DESCRIPTION
## Summary
- `fi` の後に `else` が記述されていたシンタックスエラーを修正
- 正しい `if-else-fi` 構造に変更し、GitHub Actions ワークフローが正常に実行されるように

## Related Issue
Fixes #16

## Test Plan
- [ ] GitHub Actions で check-go-version.yml が正常に実行されることを確認
- [ ] シェルスクリプトのシンタックスが正しいことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)